### PR TITLE
Fix of error when metric lines are loaded as byte array and can't be decoded

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -199,7 +199,7 @@ class GraphiteAlert(BaseAlert):
                 response = yield self.client.fetch(self.url, auth_username=self.auth_username,
                                                    auth_password=self.auth_password,
                                                    request_timeout=self.request_timeout)
-                records = (GraphiteRecord(line) for line in response.buffer)
+                records = (GraphiteRecord(line.decode('utf-8')) for line in response.buffer)
                 self.check([(getattr(record, self.method), record.target) for record in records])
                 self.notify('normal', 'Metrics are loaded', target='loading', ntype='common')
             except Exception as e:


### PR DESCRIPTION
When running graphite-beacon, value from graphite metric wasn't loaded properly. Instead of number i got `'Loading error: Type str doesn't support the buffer API'`. 

Value from URL was loaded as byte array, but parsed as string (i.e. `str.split()` was called on it). I've fixed it by decoding value to `UTF-8`. Fix should work in py2 and py3 also if metric value is loaded as string, fix won't break.
