### PR TITLE
Change no data behavior

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -128,6 +128,9 @@ class BaseAlert(_.with_metaclass(AlertFabric)):
     def check(self, records):
         for value, target in records:
             LOGGER.info("%s [%s]: %s", self.name, target, value)
+            if value is None:
+                self.notify('critical', value, target)
+                continue
             for rule in self.rules:
                 rvalue = self.get_value_for_rule(rule, target)
                 if rvalue is None:
@@ -200,7 +203,10 @@ class GraphiteAlert(BaseAlert):
                                                    auth_password=self.auth_password,
                                                    request_timeout=self.request_timeout)
                 records = (GraphiteRecord(line.decode('utf-8')) for line in response.buffer)
-                self.check([(getattr(record, self.method), record.target) for record in records])
+                data = [(None if record.empty else getattr(record, self.method), record.target) for record in records]
+                if len(data) == 0:
+                    raise ValueError('No data')
+                self.check(data)
                 self.notify('normal', 'Metrics are loaded', target='loading', ntype='common')
             except Exception as e:
                 self.notify('critical', 'Loading error: %s' % e, target='loading', ntype='common')

--- a/graphite_beacon/graphite.py
+++ b/graphite_beacon/graphite.py
@@ -8,7 +8,9 @@ class GraphiteRecord(object):
         self.step = int(step)
         self.values = list(self._values(data.rsplit(',')))
         if len(self.values) == 0:
-            raise ValueError('No data')
+            self.empty = True
+        else:
+            self.empty = False
 
     @staticmethod
     def _values(values):


### PR DESCRIPTION
The current behavior is to raise exception in the constructor of the GraphiteRecord object when a metric with zero values is loaded. This causes all of the other metrics (which could be fine) not to be loaded. In the example render API output for our disk usage gauges, the machine `disk.east.app2' is reporting metrics anymore after a statsd reset so gauge was reset. It would make the load of all of the other metrics fail.

    disk.east.app1,1421711710,1421711770,10|44.0,44.0,44.0,44.0,44.0,None
    disk.east.app2,1421711710,1421711770,10|None,None,None,None,None,None
    disk.east.app3,1421711710,1421711770,10|29.0,29.0,29.0,29.0,29.0,None
    disk.east.app4,1421711710,1421711770,10|56.0,56.0,56.0,56.0,56.0,None

The proposed change here sets a flag on the GraphiteRecord object if it does not contain any values. The list comprehension to generate the input to the check method has been modified to give None instead of the value for the metric (still no divide by zero errors). The None is then detected in the check method and a critical log message is logged for only that metric. The other metrics can still be processed. Additionally, the raise of the exception is moved to be triggered if the entire metrics response is empty.

The behavior for an empty metric is logging it as critical. I am open to changing the behavior in the future, possibly to something like `insufficient_data' like in AWS. Currently, I was just mirroring the level of the previous behavior.