### PR TITLE
Configurable time window for graphite queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Value units:
         // Can be redfined for each alert.
         "interval": "10minute",
 
+        // Default time window for Graphite queries
+        // Defaults to query interval, can be redefined for each alert.
+        "time_window": "10minute",
+
         // Notification repeat interval
         // If an alert is failed, its notification will be repeated with the interval below
         "repeat_interval": "2hour",

--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -91,6 +91,9 @@ class BaseAlert(_.with_metaclass(AlertFabric)):
             options.get('interval', self.reactor.options['interval']))
         interval = parse_interval(self.interval)
 
+        self.time_window = interval_to_graphite(
+            options.get('time_window', options.get('interval', self.reactor.options['interval'])))
+
         self._format = options.get('format', self.reactor.options['format'])
         self.request_timeout = options.get(
             'request_timeout', self.reactor.options['request_timeout'])
@@ -184,9 +187,10 @@ class GraphiteAlert(BaseAlert):
         self.auth_password = self.reactor.options.get('auth_password')
 
         query = escape.url_escape(self.query)
-        self.url = "%(base)s/render/?target=%(query)s&rawData=true&from=-%(interval)s" % {
+        self.url = "%(base)s/render/?target=%(query)s&rawData=true&from=-%(time_window)s" % {
             'base': self.reactor.options['graphite_url'], 'query': query,
-            'interval': self.interval}
+            'time_window': self.time_window}
+        LOGGER.debug('%s: url = %s' % (self.name, self.url))
 
     @gen.coroutine
     def load(self):
@@ -208,9 +212,9 @@ class GraphiteAlert(BaseAlert):
 
     def get_graph_url(self, target, graphite_url=None):
         query = escape.url_escape(target)
-        return "%(base)s/render/?target=%(query)s&from=-%(interval)s" % {
+        return "%(base)s/render/?target=%(query)s&from=-%(time_window)s" % {
             'base': graphite_url or self.reactor.options['graphite_url'], 'query': query,
-            'interval': self.interval}
+            'time_window': self.time_window}
 
 
 class URLAlert(BaseAlert):


### PR DESCRIPTION
Allow configuring the Graphite query time window (ie. the time period to fetch data from, that is the `from=-<time_window>` parameter) separately from the query interval. This allows for frequent polling while providing some smoothing of the data. For example, to poll once every minute but look at the sum over the past 5 minutes:

    "interval": "1m",
    "time_window": "5m",
    "method": "sum"

If undefined, `time_window` defaults to `interval` so the existing functionality remains unchanged.