### PR TITLE
alerts: add "sum" to METHODS

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -9,7 +9,7 @@ from itertools import islice
 
 
 LOGGER = log.gen_log
-METHODS = "average", "last_value"
+METHODS = "average", "last_value", "sum"
 LEVELS = {
     'critical': 0,
     'warning': 10,


### PR DESCRIPTION
`sum` is documented but it doesn't actually work because it's missing from
the `METHODS` constant