### PR TITLE
Don't duplicate alerts when reloading configuration.

### DIFF
--- a/graphite_beacon/core.py
+++ b/graphite_beacon/core.py
@@ -82,9 +82,7 @@ class Reactor(object):
                 with open(config) as fconfig:
                     source = COMMENT_RE.sub("", fconfig.read())
                     config = json.loads(source)
-                    alerts = self.options.get('alerts', [])
                     self.options.update(config)
-                    self.options['alerts'] = alerts + self.options.get('alerts', [])
             except (IOError, ValueError):
                 LOGGER.error('Invalid config file: %s' % config)
 

--- a/tests.py
+++ b/tests.py
@@ -21,7 +21,7 @@ def test_reactor():
     rr = Reactor(include=['example-config.json'], alerts=[
         {'name': 'test', 'query': '*', 'rules': ["normal: == 0"]}])
     assert rr.options['interval'] == '20minute'
-    assert len(rr.alerts) == 3
+    assert len(rr.alerts) == 2
 
 
 def test_alert(reactor):


### PR DESCRIPTION
Fixes an issue where the already configured alerts were combined with the alerts
in the configuration file that was being reparsed in response to a SIGHUP.

Fixes #28