### PR TITLE
Explicitly convert textual log level names to numeric log levels.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 """ TODO: Implement the tests. """
 
+import logging
 import pytest
 import mock
 
@@ -22,6 +23,28 @@ def test_reactor():
         {'name': 'test', 'query': '*', 'rules': ["normal: == 0"]}])
     assert rr.options['interval'] == '20minute'
     assert len(rr.alerts) == 2
+
+
+def test_convert_config_log_level():
+    from graphite_beacon.core import _get_numeric_log_level
+
+    assert logging.DEBUG == _get_numeric_log_level('debug')
+    assert logging.DEBUG == _get_numeric_log_level('DEBUG')
+
+    assert logging.INFO == _get_numeric_log_level('info')
+    assert logging.INFO == _get_numeric_log_level('INFO')
+
+    assert logging.WARN == _get_numeric_log_level('warn')
+    assert logging.WARN == _get_numeric_log_level('WARN')
+
+    assert logging.WARNING == _get_numeric_log_level('warning')
+    assert logging.WARNING == _get_numeric_log_level('WARNING')
+
+    assert logging.ERROR == _get_numeric_log_level('error')
+    assert logging.ERROR == _get_numeric_log_level('ERROR')
+
+    assert logging.CRITICAL == _get_numeric_log_level('critical')
+    assert logging.CRITICAL == _get_numeric_log_level('CRITICAL')
 
 
 def test_alert(reactor):


### PR DESCRIPTION
Fixes an issue in Python 2.6 where the logging.Logger.setLevel method did not
convert textual log levels to the numeric log levels, but the same method in
Python 2.7 did.

Fixes #31.