### PR TITLE
Add ability to customize alert behavior with no data

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,12 @@ Value units:
         "logging": "info",
 
         // Default method (average, last_value, sum).
-        // Can be redfined for each alert.
+        // Can be redefined for each alert.
         "method": "average",
+
+        // Default alert to send when no data received (normal = no alert)
+        // Can be redefined for each alert
+        "no_data": "critical",
 
         // Default prefix (used for notifications)
         "prefix": "[BEACON]",
@@ -213,6 +217,9 @@ At the moment **Graphite-beacon** supports two type of alerts:
 
       // (optional) Alert interval [eg. 15second, 30minute, 2hour, 1day, 3month, 1year]
       "interval": "1minute",
+
+      // (optional) What kind of alert to send when no data received (normal = no alert)
+      "no_data": "warning",
 
       // (required) Alert rules
       // Rule format: "{level}: {operator} {value}"

--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -102,6 +102,8 @@ class BaseAlert(_.with_metaclass(AlertFabric)):
         self.history_size = parse_interval(self.history_size)
         self.history_size = int(math.ceil(self.history_size / interval))
 
+        self.no_data = options.get('no_data', self.reactor.options['no_data'])
+
         if self.reactor.options.get('debug'):
             self.callback = ioloop.PeriodicCallback(self.load, 5000)
         else:
@@ -132,7 +134,7 @@ class BaseAlert(_.with_metaclass(AlertFabric)):
         for value, target in records:
             LOGGER.info("%s [%s]: %s", self.name, target, value)
             if value is None:
-                self.notify('critical', value, target)
+                self.notify(self.no_data, value, target)
                 continue
             for rule in self.rules:
                 rvalue = self.get_value_for_rule(rule, target)

--- a/graphite_beacon/core.py
+++ b/graphite_beacon/core.py
@@ -31,6 +31,7 @@ class Reactor(object):
         'interval': '10minute',
         'logging': 'info',
         'method': 'average',
+        'no_data': 'critical',
         'normal_handlers': ['log', 'smtp'],
         'pidfile': None,
         'prefix': '[BEACON]',


### PR DESCRIPTION
New 'no_data' config value can now be set to 'normal', 'warning' or 'critical' at the top-level, or per alert. Default retains the same behavior as today: 'critical' alerts. Includes associated readme updates.

#### Background

I'm using statsd to keep track of a few metrics like 'crashes', 'deploys' and 'launches.' Whenever these are non-zero, I want a notification. As you might expect, I only send data from my scripts and apps when it's non-zero. Statsd takes care of this for me, by remembering the data point after I initially send it, sending zeros thereafter (this is configurable, of course).

When I need to restart statsd or the entire machine, those data points are no longer known to statsd. Today I get critical alerts whenever this happens. This allows that logging level for 'no data' to be configured both globally and per-alert.