### PR TITLE
Support for multiple Graphites

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ Value units:
         "graphite_url": "http://localhost",
 
         // HTTP AUTH username
-        "auth_username": null,
+        "graphite_username": null,
 
         // HTTP AUTH password
-        "auth_password": null,
+        "graphite_password": null,
 
         // Path to a pidfile
         "pidfile": null,

--- a/README.md
+++ b/README.md
@@ -268,6 +268,64 @@ alerts: [
 ...
 ```
 
+### Multiple Graphites
+
+To check different Graphites describe them in config like:
+
+```js
+{
+    ...
+    // Drop params for single graphite:
+    // "graphite_url": "",
+    // "graphite_username": null,
+    // "graphite_password": null,
+
+    // Then set the list:
+    "graphites": [
+      {
+         "name": "default",
+         "url": "http://localhost",
+         "username": "username",
+         "password": "password"
+      },
+      {
+        "name": "second",
+        "url": "http://second.graphite",
+      }
+    ],
+    ...
+}
+```
+
+And set alets for each Graphite by it's name:
+
+```js
+{
+  ...
+  "alerts": [
+    {
+      // If param "graphite" is skipped alert will check the "default"
+      // "graphite": "default".
+      "name": "Memory",
+      "query": "aliasByNode(collectd.*.memory.memory-free, 1)",
+      "interval": "10minute",
+      "format": "bytes",
+      "rules": ["warning: < 300MB", "critical: > 200MB"]
+    },
+    {
+      // Alert for another graphite
+      "graphite": "second",
+      "name": "Memory",
+      "query": "aliasByNode(collectd.*.memory.memory-free, 1)",
+      "interval": "10minute",
+      "format": "bytes",
+      "rules": ["warning: < 300MB", "critical: > 200MB"]
+    },
+  ]
+  ...
+}
+```
+
 ### Setup SMTP
 
 Enable "smtp" handler (enabled by default) and set the options in your beacon

--- a/debian/config.json
+++ b/debian/config.json
@@ -7,10 +7,10 @@
     "graphite_url": "http://localhost",
 
     // HTTP AUTH username
-    "auth_username": null,
+    "graphite_username": null,
 
     // HTTP AUTH password
-    "auth_password": null,
+    "graphite_password": null,
 
     // Path to a pidfile
     "pidfile": null,
@@ -36,6 +36,6 @@
 
     // Place your alerts here
     "alerts": [
-      
+
     ]
 }

--- a/example-config.json
+++ b/example-config.json
@@ -1,30 +1,63 @@
-// Comments is allowed here
+// Comments are allowed here
 {
+  "debug": true,
+
   "interval": "20minute",
   "logging": "debug",
 
+  // For one graphite
+  "graphite_url": "http://localhost",
+  "graphite_username": "usernames",
+  "graphite_password": "password",
+
+  // For multiple graphites
+  // "graphites": [
+  //   {
+  //      "name": "default",
+  //      "url": "http://localhost",
+  //      "username": "username",
+  //      "password": "password"
+  //   },
+  //   {
+  //     "name": "second",
+  //     "url": "http://second.graphite"
+  //   }
+  // ],
+
   // Gmail example
   // "smtp": {
-    // "username": "example@gmail.com",
-    // "password": "password",
-    // "use_tls": true,
-    // "host": "smtp.gmail.com",
-    // "port": 587,
-    // "from": "myemail@gmail.com",
-    // "to": ["myemail@gmail.com"]
+  //   "username": "example@gmail.com",
+  //   "password": "password",
+  //   "use_tls": true,
+  //   "host": "smtp.gmail.com",
+  //   "port": 587,
+  //   "from": "myemail@gmail.com",
+  //   "to": ["myemail@gmail.com"]
   // },
-
-  "debug": true,
 
   "alerts": [
     // A graphite alert
     {
+      // Param "graphite" could be skipped when use only one graphite
+      // "graphite": "default".
       "name": "Memory",
       "query": "aliasByNode(collectd.*.memory.memory-free, 1)",
       "interval": "10minute",
       "format": "bytes",
       "rules": ["warning: < 300MB", "critical: > 200MB"]
     },
+
+    // Alert for another graphite
+    // {
+    //   "source": "graphite",
+    //   "graphite": "second",
+    //   "name": "Memory",
+    //   "query": "aliasByNode(collectd.*.memory.memory-free, 1)",
+    //   "interval": "10minute",
+    //   "format": "bytes",
+    //   "rules": ["warning: < 300MB", "critical: > 200MB"]
+    // },
+
     // A ping alert
     {
       "name": "Site",

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,0 +1,67 @@
+---
+debug: false
+
+interval: "20minute"
+logging: "debug"
+
+# For one graphite
+graphite_url: http://localhost
+graphite_username: usernames
+graphite_password: password
+
+# For multiple graphites
+# graphites:
+#   -
+#     name: default
+#     url: http://localhost
+#     username: username
+#     password: password
+#   -
+#     name: second
+#     url: http://second.graphite
+
+# Gmail example
+# smtp:
+#   username: "example@gmail.com"
+#   password: "password"
+#   use_tls: true
+#   host: "smtp.gmail.com"
+#   port: 587
+#   from: "myemail@gmail.com"
+#   to:
+#     - "myemail@gmail.com"
+
+alerts:
+  # A graphite alert
+  -
+    # Param "graphite" could be skipped when use only one graphite
+    # graphite: "default"
+    name: "Memory"
+    query: "aliasByNode(collectd.*.memory.memory-free, 1)"
+    interval: "10minute"
+    format: "bytes"
+    rules:
+      - "warning: < 300MB"
+      - "critical: > 200MB"
+
+  # Alert for another graphite
+  # -
+  #   source: "graphite"
+  #   graphite: "second"
+  #   name: "Memory"
+  #   query: "aliasByNode(collectd.*.memory.memory-free, 1)"
+  #   interval: "10minute"
+  #   format: "bytes"
+  #   rules:
+  #     - "warning: < 300MB"
+  #     - "critical: > 200MB"
+
+  # A ping alert
+  -
+    name: "Site"
+    # Source (graphite, url). By default: graphite
+    source: "url"
+    query: "http://google.com"
+    interval: "20second"
+    rules:
+      - "critical: != 200"

--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -186,8 +186,8 @@ class GraphiteAlert(BaseAlert):
         self.method = options.get('method', self.reactor.options['method'])
         assert self.method in METHODS, "Method is invalid"
 
-        self.auth_username = self.reactor.options.get('auth_username')
-        self.auth_password = self.reactor.options.get('auth_password')
+        self.graphite_username = self.reactor.options.get('graphite_username')
+        self.graphite_password = self.reactor.options.get('graphite_password')
 
         query = escape.url_escape(self.query)
         self.url = "%(base)s/render/?target=%(query)s&rawData=true&from=-%(time_window)s" % {
@@ -203,8 +203,8 @@ class GraphiteAlert(BaseAlert):
         else:
             self.waiting = True
             try:
-                response = yield self.client.fetch(self.url, auth_username=self.auth_username,
-                                                   auth_password=self.auth_password,
+                response = yield self.client.fetch(self.url, auth_username=self.graphite_username,
+                                                   auth_password=self.graphite_password,
                                                    request_timeout=self.request_timeout)
                 records = (GraphiteRecord(line.decode('utf-8')) for line in response.buffer)
                 data = [(None if record.empty else getattr(record, self.method), record.target) for record in records]

--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -203,9 +203,11 @@ class GraphiteAlert(BaseAlert):
         else:
             self.waiting = True
             try:
-                response = yield self.client.fetch(self.url, auth_username=self.graphite_username,
-                                                   auth_password=self.graphite_password,
-                                                   request_timeout=self.request_timeout)
+                response = yield self.client.fetch(
+                    self.url,
+                    auth_username=self.graphite_username,
+                    auth_password=self.graphite_password,
+                    request_timeout=self.request_timeout)
                 records = (GraphiteRecord(line.decode('utf-8')) for line in response.buffer)
                 data = [(None if record.empty else getattr(record, self.method), record.target) for record in records]
                 if len(data) == 0:
@@ -235,9 +237,10 @@ class URLAlert(BaseAlert):
         else:
             self.waiting = True
             try:
-                response = yield self.client.fetch(self.query,
-                                                   method=self.options.get('method', 'GET'),
-                                                   request_timeout=self.request_timeout)
+                response = yield self.client.fetch(
+                    self.query,
+                    method=self.options.get('method', 'GET'),
+                    request_timeout=self.request_timeout)
                 self.check([(response.code, self.query)])
                 self.notify('normal', 'Metrics are loaded', target='loading')
 

--- a/graphite_beacon/core.py
+++ b/graphite_beacon/core.py
@@ -25,8 +25,8 @@ class Reactor(object):
     """ Class description. """
 
     defaults = {
-        'auth_password': None,
-        'auth_username': None,
+        'graphite_username': None,
+        'graphite_password': None,
         'config': 'config.json',
         'critical_handlers': ['log', 'smtp'],
         'debug': False,

--- a/graphite_beacon/core.py
+++ b/graphite_beacon/core.py
@@ -25,13 +25,13 @@ class Reactor(object):
     """ Class description. """
 
     defaults = {
+        'graphite_url': 'http://localhost',
         'graphite_username': None,
         'graphite_password': None,
         'config': 'config.json',
         'critical_handlers': ['log', 'smtp'],
         'debug': False,
         'format': 'short',
-        'graphite_url': 'http://localhost',
         'history_size': '1day',
         'interval': '10minute',
         'logging': 'info',
@@ -59,9 +59,11 @@ class Reactor(object):
         options = dict(self.defaults)
         options.update(extra_options)
 
-        self.include_config(options.get('config'))
+        self.include_config(options, options.get('config'))
         for config in options.pop('include', []):
             self.include_config(options, config)
+
+        self.process_graphite_config(options)
 
         LOGGER.setLevel(_get_numeric_log_level(options.get('logging', 'info')))
 
@@ -95,9 +97,31 @@ class Reactor(object):
                 with open(config) as fconfig:
                     source = COMMENT_RE.sub("", fconfig.read())
                     config = loader(source)
-                    self.options.update(config)
+                    options.update(config)
             except (IOError, ValueError):
                 LOGGER.error('Invalid config file: %s' % config)
+
+    def process_graphite_config(self, options):
+        graphites = {}
+        if 'graphites' in options:
+            for graphite in options['graphites']:
+                name = graphite.get('name', 'default')
+                graphites[name] = graphite
+        else:
+            # Convert old parameters to the new format for backward compatibility
+            name = 'default'
+            graphites[name] = {
+                'name': name,
+                'url': options.get('graphite_url'),
+                'username': options.get('graphite_username'),
+                'password': options.get('graphite_password')
+            }
+
+        for param in ['graphite_url', 'graphite_username', 'graphite_password']:
+            if param in options:
+                options.pop(param)
+
+        options['graphites'] = graphites
 
     def reinit_handlers(self, options, level='warning'):
         for name in options['%s_handlers' % level]:


### PR DESCRIPTION
Adds ability to check more than one Graphite.

Describe them in config:
```js
{
    ...
    // Drop params for single graphite:
    // "graphite_url": "",
    // "graphite_username": null,
    // "graphite_password": null,

    // Then set the list:
    "graphites": [
      {
         "name": "default",
         "url": "http://localhost",
         "username": "username",
         "password": "password"
      },
      {
        "name": "another-one",
        "url": "http://another-one",
      }
    ],
    ...
}
```

And set alets for each Graphite by it's name:
```js
{
  ...
  "alerts": [
    {
      // If param "graphite" is skipped alert will check the "default"
      // "graphite": "default".
      "name": "Memory",
      "query": "aliasByNode(collectd.*.memory.memory-free, 1)",
      "interval": "10minute",
      "format": "bytes",
      "rules": ["warning: < 300MB", "critical: > 200MB"]
    },
    {
      // Alert for another graphite
      "graphite": "another-one",
      "name": "Memory",
      "query": "aliasByNode(collectd.*.memory.memory-free, 1)",
      "interval": "10minute",
      "format": "bytes",
      "rules": ["warning: < 300MB", "critical: > 200MB"]
    },
  ]
  ...
}
```
