### PR TITLE
VictorOps handler via the REST Endpoint.

### DIFF
--- a/graphite_beacon/handlers/__init__.py
+++ b/graphite_beacon/handlers/__init__.py
@@ -64,3 +64,4 @@ from .slack import SlackHandler          # noqa
 from .smtp import SMTPHandler            # noqa
 from .cli import CliHandler              # noqa
 from .opsgenie import OpsgenieHandler    # noqa
+from .victorops import VictorOpsHandler  # noqa

--- a/graphite_beacon/handlers/victorops.py
+++ b/graphite_beacon/handlers/victorops.py
@@ -1,0 +1,33 @@
+import json
+from urlparse import urljoin
+from tornado import gen, httpclient as hc
+
+from . import AbstractHandler, LOGGER
+
+
+class VictorOpsHandler(AbstractHandler):
+
+    name = 'victorops'
+
+    def init_handler(self):
+        self.url = self.options.get('endpoint')
+        assert self.url, 'REST Endpoint is not defined'
+        
+        self.routing_key = self.options.get('routing_key', 'everyone')
+        self.url = urljoin(self.url, self.routing_key)
+
+        self.client = hc.AsyncHTTPClient()
+
+    @gen.coroutine
+    def notify(self, level, alert, value, target=None, ntype=None, rule=None):
+        LOGGER.debug("Handler (%s) %s", self.name, level)
+
+        message = self.get_short(level, alert, value, target=target, ntype=ntype, rule=rule)
+        data = {'entity_display_name': alert.name, 'state_message': message, 'message_type': level}
+        if target:
+            data['target'] = target
+        if rule:
+            data['rule'] = rule['raw']
+        body = json.dumps(data)
+        headers = {'Content-Type': 'application/json;'}
+        yield self.client.fetch(self.url, method="POST", body=body, headers=headers)


### PR DESCRIPTION
Simple VictorOps handler implemented using their REST endpoint. It's really a copy of the HTTP handler already present. But since VictorOps has useful specific keys and a JSON body, I thought it would be better to keep the current HTTP handler generic as is.

Just two keys are needed to enable the handler:

```js
{
    ...
    "victorops": {
        "endpoint": "http://myendpoint.com",
        // optional - defaults to "everyone"
        "routing_key": "everyone",
    }
    ...
}
```

More info:
https://victorops.com/
http://victorops.force.com/knowledgebase/articles/Integration/Alert-Ingestion-API-Documentation/?l=en_US&fs=Search&pn=1