### PR TITLE
Add 'public_graphite_url' config option for external handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Value units:
         // Graphite server URL
         "graphite_url": "http://localhost",
 
+        // Public graphite server URL
+        // Used when notifying handlers, defaults to graphite_url
+        "public_graphite_url": null,
+
         // HTTP AUTH username
         "auth_username": null,
 
@@ -135,11 +139,11 @@ Value units:
         "pidfile": null,
 
         // Default values format (none, bytes, s, ms, short)
-        // Can be redfined for each alert.
+        // Can be redefined for each alert.
         "format": "short",
 
         // Default query interval
-        // Can be redfined for each alert.
+        // Can be redefined for each alert.
         "interval": "10minute",
 
         // Default time window for Graphite queries

--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -242,7 +242,8 @@ class GraphiteAlert(BaseAlert):
     def _graphite_url(self, query, raw_data=False, graphite_url=None):
         """ Build Graphite URL. """
         query = escape.url_escape(query)
-        graphite_url = graphite_url or self.reactor.options['graphite_url']
+        graphite_url = graphite_url or self.reactor.options.get('public_graphite_url')
+
         url = "{base}/render/?target={query}&from=-{time_window}&until=-{until}".format(
             base=graphite_url, query=query, time_window=self.time_window, until=self.until)
         if raw_data:

--- a/graphite_beacon/core.py
+++ b/graphite_beacon/core.py
@@ -32,6 +32,7 @@ class Reactor(object):
         'debug': False,
         'format': 'short',
         'graphite_url': 'http://localhost',
+        'public_graphite_url': None,
         'history_size': '1day',
         'interval': '10minute',
         'until': '0second',
@@ -63,6 +64,9 @@ class Reactor(object):
         self.include_config(self.options.get('config'))
         for config in self.options.pop('include', []):
             self.include_config(config)
+
+        if not self.options['public_graphite_url']:
+            self.options['public_graphite_url'] = self.options['graphite_url']
 
         LOGGER.setLevel(_get_numeric_log_level(self.options.get('logging', 'info')))
         registry.clean()

--- a/graphite_beacon/handlers/opsgenie.py
+++ b/graphite_beacon/handlers/opsgenie.py
@@ -22,7 +22,7 @@ class OpsgenieHandler(AbstractHandler):
 
         message = self.get_short(level, alert, value, target, *args, **kwargs)
         description = "{url}/composer/?{params}".format(
-                        url=self.reactor.options['graphite_url'],
+                        url=self.reactor.options['public_graphite_url'],
                         params=urllib.urlencode({'target': alert.query}))
         alias = target + ':' + alert.name
 

--- a/tests.py
+++ b/tests.py
@@ -47,6 +47,17 @@ def test_convert_config_log_level():
     assert logging.CRITICAL == _get_numeric_log_level('CRITICAL')
 
 
+def test_public_graphite_url():
+    from graphite_beacon.core import Reactor
+
+    rr = Reactor(graphite_url='http://localhost', public_graphite_url=None)
+    rr.reinit()
+    assert rr.options.get("public_graphite_url") == 'http://localhost'
+
+    rr.reinit(public_graphite_url="http://public")
+    assert rr.options.get("public_graphite_url") == "http://public"
+
+
 def test_alert(reactor):
     from graphite_beacon.alerts import BaseAlert, GraphiteAlert, URLAlert
 


### PR DESCRIPTION
Allow a different "external" URL for when alerts are sent. 

Something similar exists in the SMTP email handler by allowing another `graphite_url` parameter, so this pulls it out into the root configuration level to make it available for all handlers.