### PR TITLE
English correction: Comments "are" allowed here

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -1,4 +1,4 @@
-// Comments is allowed here
+// Comments are allowed here
 {
   "interval": "20minute",
   "logging": "debug",


### PR DESCRIPTION
Just a simple English correction in `example-config.json`: Comments "are" allowed here