### PR TITLE
Added support for url-checking on urls with invalid SSL certificates.

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -266,7 +266,8 @@ class URLAlert(BaseAlert):
             try:
                 response = yield self.client.fetch(self.query,
                                                    method=self.options.get('method', 'GET'),
-                                                   request_timeout=self.request_timeout)
+                                                   request_timeout=self.request_timeout,
+                                                   validate_cert=self.options.get('validate_cert', True))
                 self.check([(response.code, self.query)])
                 self.notify('normal', 'Metrics are loaded', target='loading')
 


### PR DESCRIPTION
Checking can be disabled by setting "validate_cert": false
Default is true.
This is useful for checking URL's within your environment which have some specific entries where the URL doesn't match the certificate.