### PR TITLE
allow customize the connect_timeout

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -109,6 +109,8 @@ class BaseAlert(_.with_metaclass(AlertFabric)):
         self._format = options.get('format', self.reactor.options['format'])
         self.request_timeout = options.get(
             'request_timeout', self.reactor.options['request_timeout'])
+        self.connect_timeout = options.get(
+            'connect_timeout', self.reactor.options['connect_timeout'])
 
         self.history_size = options.get('history_size', self.reactor.options['history_size'])
         self.history_size = parse_interval(self.history_size)
@@ -235,7 +237,8 @@ class GraphiteAlert(BaseAlert):
             try:
                 response = yield self.client.fetch(self.url, auth_username=self.auth_username,
                                                    auth_password=self.auth_password,
-                                                   request_timeout=self.request_timeout)
+                                                   request_timeout=self.request_timeout,
+                                                   connect_timeout=self.connect_timeout)
                 records = (
                     GraphiteRecord(line.decode('utf-8'), self.default_nan_value, self.ignore_nan)
                     for line in response.buffer)
@@ -284,6 +287,7 @@ class URLAlert(BaseAlert):
                 response = yield self.client.fetch(
                     self.query, method=self.options.get('method', 'GET'),
                     request_timeout=self.request_timeout,
+                    connect_timeout=self.connect_timeout,
                     validate_cert=self.options.get('validate_cert', True))
                 self.check([(self.get_data(response), self.query)])
                 self.notify('normal', 'Metrics are loaded', target='loading', ntype='common')

--- a/graphite_beacon/core.py
+++ b/graphite_beacon/core.py
@@ -43,6 +43,7 @@ class Reactor(object):
         'public_graphite_url': None,
         'repeat_interval': '2hour',
         'request_timeout': 20.0,
+        'connect_timeout': 20.0,
         'send_initial': False,
         'until': '0second',
         'warning_handlers': ['log', 'smtp'],


### PR DESCRIPTION
i have seen lots of timeout (599) error when running graphite-beacon with ~ 700 metrics. the reason seems because of the default connect timeout (20 seconds in based on http://tornado.readthedocs.org/en/latest/_modules/tornado/httpclient.html) may not be enough if the graphite-beacon have lots of metrics to check.



