### PR TITLE
Add support for interval cron expressions

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -43,7 +43,7 @@ class sliceable_deque(deque):
 
 def is_cron(expr):
     """Detect if an expression is a valid cron expression."""
-    return expr is not None and len(expr.split()) >= 5
+    return expr is not None and len(expr.split()) == 5
 
 
 class CronCallback(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tornado == 4.1.0
 funcparserlib==0.3.6
+croniter==0.3.10

--- a/tests.py
+++ b/tests.py
@@ -76,6 +76,9 @@ def test_alert(reactor):
     assert alert1 == alert3
     assert set([alert1, alert3]) == set([alert1])
 
+    alert4 = BaseAlert.get(reactor, name='Test', query='*', interval='*/10 09-18 * * 1-5', time_window='1h', rules=["normal: == 0"])
+    assert alert4.interval == '*/10 09-18 * * 1-5'
+
     alert = BaseAlert.get(reactor, name='Test', query='*', rules=["warning: >= 3MB"])
     assert alert.rules[0]['exprs'][0]['value'] == 3145728
 

--- a/tests.py
+++ b/tests.py
@@ -78,6 +78,8 @@ def test_alert(reactor):
 
     alert4 = BaseAlert.get(reactor, name='Test', query='*', interval='*/10 09-18 * * 1-5', time_window='1h', rules=["normal: == 0"])
     assert alert4.interval == '*/10 09-18 * * 1-5'
+    alert4.start()
+    alert4.stop()
 
     alert = BaseAlert.get(reactor, name='Test', query='*', rules=["warning: >= 3MB"])
     assert alert.rules[0]['exprs'][0]['value'] == 3145728

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     mock
     pytest
     tornado
+    croniter
 
 [testenv:cov]
 deps =


### PR DESCRIPTION
I am using graphite-beacon to monitor a production service that sees varying load patterns throughout the day and by day of week. I've added the ability to use cron syntax to schedule checks, rather than a fixed interval. This allows me to have alerts with certain thresholds for weekdays and work hours, with different thresholds for off-peak hours.