### PR TITLE
Allow notifications to slack users too.

### DIFF
--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -28,7 +28,7 @@ class SlackHandler(AbstractHandler):
         assert self.webhook, 'Slack webhook is not defined.'
 
         self.channel = self.options.get('channel')
-        if self.channel and not self.channel.startswith('#'):
+        if self.channel and not self.channel.startswith(('#', '@')):
             self.channel = '#' + self.channel
         self.username = self.options.get('username')
         self.client = hc.AsyncHTTPClient()


### PR DESCRIPTION
Allow notifications to slack users too.
If the channel name starts with @ the notification(s) will be sent to the specified slack user.