### PR TITLE
make telegram handler persist chats/groups across sessions, fix json serialization bug, fix key error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
   - master
   - develop
 
-install: pip install --quiet --use-mirrors tox
+install: pip install --quiet tox
 
 script: tox
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ Sends a Telegram message.
 {
     "telegram": {
         "token": "telegram bot token",
-        "bot_ident": "token used to activate bot in a group"
+        "bot_ident": "token you choose to activate bot in a group"
+        "chatfile": "path to file where chat id`s are saved"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Sends a Telegram message.
     "telegram": {
         "token": "telegram bot token",
         "bot_ident": "token you choose to activate bot in a group"
-        "chatfile": "path to file where chat id`s are saved"
+        "chatfile": "path to file where chat ids are saved, optional field"
     }
 }
 ```

--- a/graphite_beacon/handlers/telegram.py
+++ b/graphite_beacon/handlers/telegram.py
@@ -30,7 +30,8 @@ class TelegramHandler(AbstractHandler):
         assert self.bot_ident, 'Telegram bot ident token is not defined.'
 
         self.chatfile = self.options.get('chatfile')
-        if not self.chatfile: LOGGER.warning(NO_CHATFILE)
+        if not self.chatfile:
+            LOGGER.warning(NO_CHATFILE)
 
         self.client = httpclient.AsyncHTTPClient()
         self.url = 'https://api.telegram.org/bot%s/' % (self.token)
@@ -73,7 +74,7 @@ class TelegramHandler(AbstractHandler):
             update_id = update.get('update_id')
             if not update_id: continue
 
-            message = update.get('message')  # fix key error here
+            message = update.get('message')
             if not message: continue
 
             text = message.get('text')
@@ -132,11 +133,11 @@ class TelegramHandler(AbstractHandler):
             with open(self.chatfile) as fh:
                 return [int(chat) for chat in fh]
         except Exception as e:
-            LOGGER.debug('could not load saved chats:\n%s' % (e))
+            LOGGER.error('could not load saved chats:\n%s' % (e))
             return []
 
     def _prepare_request(self, target, body, method='POST',
-                            headers={"Content-Type": "application/json"}):
+                        headers={"Content-Type": "application/json"}):
 
         return dict(request=self.url + target, body=json.dumps(body),
                     method=method, headers=headers,)
@@ -149,7 +150,7 @@ class TelegramHandler(AbstractHandler):
         """
         splitted = text.split()
         init = splitted[0].strip().lower()
-        init_iscorrect = init.startswith(r'/activate')
+        init_iscorrect = init.startswith('/activate')
 
         if int(chat_id) > 0:
             return init_iscorrect

--- a/graphite_beacon/handlers/telegram.py
+++ b/graphite_beacon/handlers/telegram.py
@@ -1,14 +1,29 @@
 import json
+from os.path import exists
+import functools
 from tornado import gen, httpclient
 
 from graphite_beacon.handlers import AbstractHandler, LOGGER
 from graphite_beacon.template import TEMPLATES
 
-NO_CHATFILE = (
-    'chatfile not found in configs. If you want telegram handler to '
-    'persist chats and groups in which you activate bot after '
-    'graphite-beacon is restarted, create blank text file and write '
-    'it`s path to chatfile field in your config file.')
+HELP_MESSAGE = """Telegram handler for graphite-beacon
+usage: /command [parameters]
+examples:
+/activate my_token123
+/deactivate my_token123
+commands:
+activate - activate bot and remember this chat (no need to activate every time)
+deactivate - deactivate bot and forget this chat
+help - see this message
+every command must be preceded by slash symbol (/)
+parameters:
+bot_ident - mandatory for Telegram groups
+parameters must be separated by whitespace
+"""
+
+BOT_COMMAND_ERRORS = {
+    'wrong_ident': 'Could not parse command: wrong bot ident',
+    'no_ident': 'Could not parse command: bot ident is missing',}
 
 class TelegramHandler(AbstractHandler):
 
@@ -29,161 +44,104 @@ class TelegramHandler(AbstractHandler):
         self.bot_ident = self.options.get('bot_ident')
         assert self.bot_ident, 'Telegram bot ident token is not defined.'
 
-        self.chatfile = self.options.get('chatfile')
-        if not self.chatfile:
-            LOGGER.warning(NO_CHATFILE)
+        file = self.options.get('chatfile')
+        if not file:
+            LOGGER.warning('chatfile not found in configs')
+        elif not exists(file):
+            LOGGER.error('chatfile specified in configs doesnt exist')
+            file = None
+        self.chatfile = file
+        self.chats = get_chatlist(self.chatfile)
 
-        self.client = httpclient.AsyncHTTPClient()
-        self.url = 'https://api.telegram.org/bot%s/' % (self.token)
-
-        self._chats = self._get_chatlist()
+        self._client = httpclient.AsyncHTTPClient()
+        self._url = 'https://api.telegram.org/bot%s/' % (self.token)
+        self.getUpdates = self._fetchmaker('getUpdates')
+        self.sendMessage = self._fetchmaker('sendMessage')
+        
         self._listen_commands()
+
+    def _fetchmaker(self, telegram_api_method):
+        request = self._url + telegram_api_method
+        fetch = self._client.fetch
+        headers={'Content-Type': 'application/json'}
+
+        def _fetcher(body):
+            body = json.dumps(body)
+            return fetch(
+                request=request, body=body, method='POST', headers=headers)
+        return _fetcher
 
     @gen.coroutine
     def _listen_commands(self):
 
         self._last_update = None
-
-        update_body = {"timeout": 2}
+        update_body = {'timeout': 2}
 
         while True:
-
-            if self._last_update:
-                # increase offset to filter out older updates
-                update_body.update({"offset": self._last_update + 1})
-
-            req = self._prepare_request('getUpdates', update_body)
-            update_resp = self.client.fetch(**req)
-
+            latest = self._last_update
+            # increase offset to filter out older updates
+            update_body.update({'offset': latest+1} if latest else {})
+            update_resp = self.getUpdates(update_body)
             update_resp.add_done_callback(self._respond_commands)
             yield gen.sleep(5)
 
     @gen.coroutine
     def _respond_commands(self, update_response):
         chatfile = self.chatfile
+        chats = self.chats
 
-        if update_response.exception():
-            LOGGER.error(str(update_response.exception()))
-
-        upd = update_response.result().body
+        exc, upd = update_response.exception(), update_response.result().body
+        if exc:
+            LOGGER.error(str(exc))
         if not upd:
             return
 
-        update_content = json.loads(upd.decode())
-        for update in update_content['result']:
-
-            params = TelegramHandler._traverse(update)
-            if not params['ok']:
-                continue
-
-            update_id, chat_id, message_id, text = params['data']
-
-            if not self._correct_activation(text, chat_id):
-                continue
-
+        data = get_data(upd, self.bot_ident)
+        for (update_id, chat_id, message_id, command) in data:
             self._last_update = update_id
+            chat_is_known = (chat_id in chats)
+            reply_text = None
 
-            if chat_id not in self._chats:
-                reply_text = 'Activated!'
+            if command == '/activate':
+                if chat_is_known:
+                    reply_text = 'This chat is already activated.'
+                else:
+                    LOGGER.debug(
+                            'Adding chat [%s] to notify list.', chat_id)
+                    reply_text = 'Activated.'
+                    chats.add(chat_id)
+                    if chatfile:
+                        write_to_file(chats, chatfile)
 
-                LOGGER.debug('Adding chat [%s] to notify list'
-                                % (chat_id))
-                self._chats.append(int(chat_id))
+            elif command == '/deactivate':
+                if chat_is_known:
+                    LOGGER.debug(
+                            'Deleting chat [%s] from notify list.', chat_id)
+                    reply_text = 'Deactivated.'
+                    chats.remove(chat_id)
+                    if chatfile:
+                        write_to_file(chats, chatfile)
 
-                if chatfile:
-                    LOGGER.debug('Writing chat [%s] to file %s'
-                                    % (chat_id, chatfile))
-                    self._save_to_file(chat_id, chatfile)
+            elif command == '/help':
+                reply_text = HELP_MESSAGE
 
             else:
-                reply_text = 'This chat is already activated'
+                LOGGER.warning(BOT_COMMAND_ERRORS[command])
 
-            response_body = {
-                "chat_id": chat_id,
-                "reply_to_message_id": message_id,
-                "text": reply_text}
-
-            bot_response = self._prepare_request('sendMessage', response_body)
-            yield self.client.fetch(**bot_response)
+            if reply_text:
+                yield self.sendMessage({
+                        'chat_id': chat_id,
+                        'reply_to_message_id': message_id,
+                        'text': reply_text,})
 
     @gen.coroutine
     def notify(self, level, *args, **kwargs):
-        request_url = self.url + 'sendMessage'
 
         LOGGER.debug('Handler (%s) %s', self.name, level)
 
         notify_text = self.get_message(level, *args, **kwargs)
-        for chat in self._chats:
-
-            body = {"chat_id": chat, "text": notify_text}
-            notification = self._prepare_request('sendMessage', body)
-
-            yield self.client.fetch(**notification)
-
-    def _get_chatlist(self):
-        try:
-            with open(self.chatfile) as fh:
-                return [int(chat) for chat in fh]
-        except Exception as e:
-            LOGGER.error('could not load saved chats:\n%s' % (e))
-            return []
-
-    def _prepare_request(self, target, body, method='POST',
-                        headers={"Content-Type": "application/json"}):
-
-        return dict(request=self.url + target, body=json.dumps(body),
-                    method=method, headers=headers,)
-
-    @staticmethod
-    def _traverse(update):
-        """As of now (october 2016), Telegram bot api
-        has getUpdates method which returns an array of
-        update objects.
-        update object always has update_id field and (usually) one
-        (and only one) optional field.
-        As of now, the only case we are interested in is when this
-        optional field is a message object, so we filter out updates
-        without message.
-        Message object might also not contain any text. Rest of fields
-        are mandatory.
-        """
-        msg = update.get('message', {})
-        text = msg.get('text')
-        if not all(msg, text):
-            return {'ok': False, 'data':()}
-
-        upd_id = update['id']
-        msg_id = msg['message_id']
-        chat_id = msg['chat']['id']
-
-        return {'ok': True,
-                'data': (upd_id, chat_id, msg_id, text)}
-
-    def _correct_activation(self, text, chat_id):
-        """Helper method, called from _respond_commands
-        when bot gets message from user.
-        chat_id is positive for 'simple' telegram chats, and
-        negative for groups.
-        In the first case, there is no need to check bot_ident.
-        """
-        splitted = text.split()
-        init = splitted[0].strip().lower()
-        init_iscorrect = init.startswith('/activate')
-
-        if int(chat_id) > 0:
-            return init_iscorrect
-
-        elif len(splitted) >= 2:
-            bot_id = splitted[1].strip()
-            bot_id_iscorrect = bot_id.startswith(self.bot_ident)
-            return (init_iscorrect and bot_id_iscorrect)
-
-        else:
-            return False
-
-    def _save_to_file(self, chat_id, chatfile):
-        with open(chatfile, 'a') as fh:
-            fh.write('%s\n' % (chat_id))
+        for chat in self.chats:
+            yield self.sendMessage({"chat_id": chat, "text": notify_text})
 
     def get_message(self, level, alert, value,
                     target=None, ntype=None, rule=None):
@@ -194,3 +152,65 @@ class TelegramHandler(AbstractHandler):
             level=level, reactor=self.reactor, alert=alert,
             value=value, target=target,)
         return generated.decode().strip()
+
+def write_to_file(chats, chatfile):
+    with open(chatfile, 'w') as fh:
+        chats = map(str, chats)
+        fh.write('\n'.join(chats))
+
+def get_chatlist(chatfile):
+    if not chatfile:
+        return set()
+    try:
+        with open(chatfile) as fh:
+            return set(int(chat) for chat in fh)
+    except Exception as e:
+        LOGGER.error('could not load saved chats:\n%s' % (e))
+        return set()
+
+def get_data(upd, bot_ident):
+    update_content = json.loads(upd.decode())
+    result = update_content['result']
+    data = (get_fields(update, bot_ident) for update in result)
+    return filter(None, data)
+
+def get_fields(upd, bot_ident):
+    """In telegram api, not every update has message field,
+    and not every message has update field.
+    We skip those cases. Rest of fields are mandatory.
+    We also skip if text is not a valid command to handler.
+    """
+    msg = upd.get('message', {})
+    text = msg.get('text')
+    if not text:
+        return
+    chat_id  = msg['chat']['id']
+    command = filter_commands(text, chat_id, bot_ident)
+    if not command:
+        return
+    return (upd['update_id'], chat_id, msg['message_id'], command)
+
+def filter_commands(text, chat_id, correct_ident):
+    """Check if text is valid command to bot.
+    Return string(either some command or error name) or None.
+    Telegram group may have many participants including bots,
+    so we need to check bot identifier to make sure command is
+    given to our bot.
+    """
+    is_group = (chat_id < 0) # always negative for groups
+    splitted = text.split()[:2]
+    command = splitted[0].strip().lower()
+
+    # make sure command is known
+    if command not in ('/activate', '/deactivate', '/help'):
+        return
+    # dont check bot_ident if not in group
+    if not is_group:
+        return command
+    # check bot_ident
+    if len(splitted)<2:
+        return 'no_ident'
+    if splitted[1].strip() != correct_ident:
+        return 'wrong_ident'
+    
+    return command

--- a/graphite_beacon/handlers/telegram.py
+++ b/graphite_beacon/handlers/telegram.py
@@ -4,7 +4,6 @@ from tornado import gen, httpclient
 from graphite_beacon.handlers import AbstractHandler, LOGGER
 from graphite_beacon.template import TEMPLATES
 
-
 class TelegramHandler(AbstractHandler):
 
     name = 'telegram'
@@ -24,33 +23,36 @@ class TelegramHandler(AbstractHandler):
         assert self.bot_ident, 'Telegram bot ident token is not defined.'
 
         self.client = httpclient.AsyncHTTPClient()
-        self.url = "https://api.telegram.org/bot%s/" % (self.token)
+        self.url = 'https://api.telegram.org/bot%s/' % (self.token)
 
         self._chats = []
         self._listen_commands()
 
-    def get_message(self, level, alert, value, target=None, ntype=None, rule=None):
+    def get_message(self, level, alert, value,
+                    target=None, ntype=None, rule=None):
 
         msg_type = 'telegram' if ntype == 'graphite' else 'short'
         tmpl = TEMPLATES[ntype][msg_type]
-        return tmpl.generate(
-            level=level, reactor=self.reactor, alert=alert, value=value, target=target).strip()
+        generated = tmpl.generate(
+            level=level, reactor=self.reactor, alert=alert,
+            value=value, target=target)
+        return generated.decode().strip()
 
     @gen.coroutine
     def _listen_commands(self):
 
         self._last_update = None
 
-        update_body = {"timeout": 2}
+        update_body = {'timeout': 2}
 
-        update_headers = {"Content-Type": "application/json"}
+        update_headers = {'Content-Type': 'application/json'}
 
         while True:
             if self._last_update:
-                update_body.update({"offset": self._last_update + 1})
+                update_body.update({'offset': self._last_update + 1})
             update_resp = self.client.fetch(
-                self.url + "getUpdates", headers=update_headers,
-                body=json.dumps(update_body), method="POST")
+                self.url + 'getUpdates', headers=update_headers,
+                body=json.dumps(update_body), method='POST')
             update_resp.add_done_callback(self._respond_commands)
             yield gen.sleep(5)
 
@@ -64,36 +66,42 @@ class TelegramHandler(AbstractHandler):
         if not update_content:
             return
         else:
-            update_content = json.loads(update_content)
+            update_content = json.loads(update_content.decode())
 
-        for update in update_content["result"]:
-            if not update["message"].get('text'):
+        for update in update_content['result']:
+
+            msg = update.get('message')
+            if not msg:
                 continue
-            message = update["message"]["text"].encode("utf-8")
-            msp = message.split()
-            self._last_update = update["update_id"]
-            if len(msp) > 1 and msp[0].startswith("/activate"):
+
+            text = msg.get('text')
+            if not text:
+                continue
+
+            msp = text.split()
+            self._last_update = update['update_id']
+            if len(msp) > 1 and msp[0].startswith('/activate'):
                 try:
-                    chat_id = update["message"]["chat"]["id"]
+                    chat_id = msg['chat']['id']
                     if msp[1] == self.bot_ident and chat_id not in self._chats:
                         LOGGER.debug(
-                            "Adding chat [%s] to notify list.", chat_id)
+                            'Adding chat [%s] to notify list.', chat_id)
                         self._chats.append(chat_id)
                         yield self.client.fetch(
-                            self.url + "sendMessage", body=json.dumps({
-                                "chat_id": update["message"]["chat"]["id"],
-                                "reply_to_message_id": update["message"]["message_id"],
-                                "text": "Activated!"}),
-                            method="POST",
-                            headers={"Content-Type": "application/json"})
+                            self.url + 'sendMessage', body=json.dumps({
+                                'chat_id': chat_id,
+                                'reply_to_message_id': msg['message_id'],
+                                'text': 'Activated!'}),
+                            method='POST',
+                            headers={'Content-Type': 'application/json'})
                     elif msp[1] == self.bot_ident and chat_id in self._chats:
                         yield self.client.fetch(
-                            self.url + "sendMessage", body=json.dumps({
-                                "chat_id": update["message"]["chat"]["id"],
-                                "reply_to_message_id": update["message"]["message_id"],
-                                "text": "This chat is already activated."}),
-                            method="POST",
-                            headers={"Content-Type": "application/json"})
+                            self.url + 'sendMessage', body=json.dumps({
+                                'chat_id': update['message']['chat']['id'],
+                                'reply_to_message_id': update['message']['message_id'],
+                                'text': 'This chat is already activated.'}),
+                            method='POST',
+                            headers={'Content-Type': 'application/json'})
                 except:
                     continue
             else:
@@ -102,10 +110,10 @@ class TelegramHandler(AbstractHandler):
     @gen.coroutine
     def notify(self, level, *args, **kwargs):
 
-        LOGGER.debug("Handler (%s) %s", self.name, level)
+        LOGGER.debug('Handler (%s) %s', self.name, level)
 
         message = self.get_message(level, *args, **kwargs)
         for chat in self._chats:
             yield self.client.fetch(
-                self.url + "sendMessage", body=json.dumps({"chat_id": chat, "text": message}),
-                method="POST", headers={"Content-Type": "application/json"})
+                self.url + 'sendMessage', body=json.dumps({'chat_id': chat, 'text': message}),
+                method='POST', headers={'Content-Type': 'application/json'})

--- a/graphite_beacon/handlers/telegram.py
+++ b/graphite_beacon/handlers/telegram.py
@@ -1,31 +1,38 @@
+"""Send alerts to telegram chats"""
+
 import json
 from os.path import exists
-import functools
 from tornado import gen, httpclient
 
 from graphite_beacon.handlers import AbstractHandler, LOGGER
 from graphite_beacon.template import TEMPLATES
 
 HELP_MESSAGE = """Telegram handler for graphite-beacon
-usage: /command [parameters]
-examples:
-/activate my_token123
-/deactivate my_token123
-commands:
-activate - activate bot and remember this chat (no need to activate every time)
-deactivate - deactivate bot and forget this chat
-help - see this message
-every command must be preceded by slash symbol (/)
-parameters:
-bot_ident - mandatory for Telegram groups
-parameters must be separated by whitespace
+*usage* /command [parameters]
+*examples*
+/activate token123
+/deactivate token123
+*commands*
+_activate_      activate bot and remember this chat
+(no need to activate next time)
+_deactivate_    deactivate bot and forget this chat
+_help_          see this message
+note: every command must be preceded by slash symbol (/)
+*parameters*
+_bot-ident_     mandatory for Telegram groups
+note: parameters must be separated by whitespace
 """
 
-BOT_COMMAND_ERRORS = {
-    'wrong_ident': 'Could not parse command: wrong bot ident',
-    'no_ident': 'Could not parse command: bot ident is missing',}
 
 class TelegramHandler(AbstractHandler):
+    """uses telegram bot api to send alerts
+    To make it work you want to:
+    - create bot and write its token to configs:
+    https://core.telegram.org/bots#3-how-do-i-create-a-bot
+    - make up some bot_ident and write it to configs
+    - optionally, make blank file for storing chats (chatfile)
+    and write its path to configs
+    """
 
     name = 'telegram'
 
@@ -38,41 +45,31 @@ class TelegramHandler(AbstractHandler):
 
     def init_handler(self):
 
-        self.token = self.options.get('token')
-        assert self.token, 'Telegram bot API token is not defined.'
+        token = self.options.get('token')
+        assert token, 'Telegram bot API token is not defined.'
+
+        self.client = CustomClient(token)
 
         self.bot_ident = self.options.get('bot_ident')
         assert self.bot_ident, 'Telegram bot ident token is not defined.'
 
-        file = self.options.get('chatfile')
-        if not file:
+        chatfile = self.options.get('chatfile')
+        if not chatfile:
             LOGGER.warning('chatfile not found in configs')
-        elif not exists(file):
-            LOGGER.error('chatfile specified in configs doesnt exist')
-            file = None
-        self.chatfile = file
+        elif not exists(chatfile):
+            LOGGER.error('chatfile specified in configs does not exist')
+            chatfile = None
+        self.chatfile = chatfile
         self.chats = get_chatlist(self.chatfile)
 
-        self._client = httpclient.AsyncHTTPClient()
-        self._url = 'https://api.telegram.org/bot%s/' % (self.token)
-        self.getUpdates = self._fetchmaker('getUpdates')
-        self.sendMessage = self._fetchmaker('sendMessage')
-        
         self._listen_commands()
-
-    def _fetchmaker(self, telegram_api_method):
-        request = self._url + telegram_api_method
-        fetch = self._client.fetch
-        headers={'Content-Type': 'application/json'}
-
-        def _fetcher(body):
-            body = json.dumps(body)
-            return fetch(
-                request=request, body=body, method='POST', headers=headers)
-        return _fetcher
 
     @gen.coroutine
     def _listen_commands(self):
+        """Monitor new updates and send them further to
+        self._respond_commands, where bot actions
+        are decided.
+        """
 
         self._last_update = None
         update_body = {'timeout': 2}
@@ -80,13 +77,18 @@ class TelegramHandler(AbstractHandler):
         while True:
             latest = self._last_update
             # increase offset to filter out older updates
-            update_body.update({'offset': latest+1} if latest else {})
-            update_resp = self.getUpdates(update_body)
+            update_body.update({'offset': latest + 1} if latest else {})
+            update_resp = self.client.get_updates(update_body)
             update_resp.add_done_callback(self._respond_commands)
             yield gen.sleep(5)
 
     @gen.coroutine
     def _respond_commands(self, update_response):
+        """Extract commands to bot from update and
+        act accordingly. For description of commands,
+        see HELP_MESSAGE variable on top of this module.
+        """
+
         chatfile = self.chatfile
         chats = self.chats
 
@@ -97,9 +99,10 @@ class TelegramHandler(AbstractHandler):
             return
 
         data = get_data(upd, self.bot_ident)
-        for (update_id, chat_id, message_id, command) in data:
+        for update_id, chat_id, message_id, command in data:
             self._last_update = update_id
-            chat_is_known = (chat_id in chats)
+            chat_is_known = chat_id in chats
+            chats_changed = False
             reply_text = None
 
             if command == '/activate':
@@ -107,44 +110,56 @@ class TelegramHandler(AbstractHandler):
                     reply_text = 'This chat is already activated.'
                 else:
                     LOGGER.debug(
-                            'Adding chat [%s] to notify list.', chat_id)
+                        'Adding chat [%s] to notify list.', chat_id)
                     reply_text = 'Activated.'
                     chats.add(chat_id)
-                    if chatfile:
-                        write_to_file(chats, chatfile)
+                    chats_changed = True
 
             elif command == '/deactivate':
                 if chat_is_known:
                     LOGGER.debug(
-                            'Deleting chat [%s] from notify list.', chat_id)
+                        'Deleting chat [%s] from notify list.', chat_id)
                     reply_text = 'Deactivated.'
                     chats.remove(chat_id)
-                    if chatfile:
-                        write_to_file(chats, chatfile)
+                    chats_changed = True
+
+            if chats_changed and chatfile:
+                write_to_file(chats, chatfile)
 
             elif command == '/help':
                 reply_text = HELP_MESSAGE
 
             else:
-                LOGGER.warning(BOT_COMMAND_ERRORS[command])
+                LOGGER.warning('Could not parse command: '
+                               'bot ident is wrong or missing')
 
             if reply_text:
-                yield self.sendMessage({
-                        'chat_id': chat_id,
-                        'reply_to_message_id': message_id,
-                        'text': reply_text,})
+                yield self.client.send_message({
+                    'chat_id': chat_id,
+                    'reply_to_message_id': message_id,
+                    'text': reply_text,
+                    'parse_mode': 'Markdown',
+                })
 
     @gen.coroutine
     def notify(self, level, *args, **kwargs):
+        """Sends alerts to telegram chats.
+        This method is called from top level module.
+        Do not rename it.
+        """
 
         LOGGER.debug('Handler (%s) %s', self.name, level)
 
         notify_text = self.get_message(level, *args, **kwargs)
-        for chat in self.chats:
-            yield self.sendMessage({"chat_id": chat, "text": notify_text})
+        for chat in self.chats.copy():
+            data = {"chat_id": chat, "text": notify_text}
+            yield self.client.send_message(data)
 
-    def get_message(self, level, alert, value,
-                    target=None, ntype=None, rule=None):
+    def get_message(self, level, alert, value, **kwargs):
+        """Standart alert message. Same format across all
+        graphite-beacon handlers.
+        """
+        target, ntype = kwargs.get('target'), kwargs.get('ntype')
 
         msg_type = 'telegram' if ntype == 'graphite' else 'short'
         tmpl = TEMPLATES[ntype][msg_type]
@@ -153,26 +168,34 @@ class TelegramHandler(AbstractHandler):
             value=value, target=target,)
         return generated.decode().strip()
 
+
 def write_to_file(chats, chatfile):
-    with open(chatfile, 'w') as fh:
-        chats = map(str, chats)
-        fh.write('\n'.join(chats))
+    """called every time chats are modified"""
+    with open(chatfile, 'w') as handler:
+        handler.write('\n'.join((str(id_) for id_ in chats)))
+
 
 def get_chatlist(chatfile):
+    """Try reading ids of saved chats from file.
+    If we fail, return empty set"""
     if not chatfile:
         return set()
     try:
-        with open(chatfile) as fh:
-            return set(int(chat) for chat in fh)
-    except Exception as e:
-        LOGGER.error('could not load saved chats:\n%s' % (e))
+        with open(chatfile) as file_contents:
+            return set(int(chat) for chat in file_contents)
+    except (OSError, IOError) as exc:
+        LOGGER.error('could not load saved chats:\n%s', exc)
         return set()
 
+
 def get_data(upd, bot_ident):
+    """Parse telegram update."""
+
     update_content = json.loads(upd.decode())
     result = update_content['result']
     data = (get_fields(update, bot_ident) for update in result)
-    return filter(None, data)
+    return (dt for dt in data if dt is not None)
+
 
 def get_fields(upd, bot_ident):
     """In telegram api, not every update has message field,
@@ -184,11 +207,12 @@ def get_fields(upd, bot_ident):
     text = msg.get('text')
     if not text:
         return
-    chat_id  = msg['chat']['id']
+    chat_id = msg['chat']['id']
     command = filter_commands(text, chat_id, bot_ident)
     if not command:
         return
     return (upd['update_id'], chat_id, msg['message_id'], command)
+
 
 def filter_commands(text, chat_id, correct_ident):
     """Check if text is valid command to bot.
@@ -197,9 +221,9 @@ def filter_commands(text, chat_id, correct_ident):
     so we need to check bot identifier to make sure command is
     given to our bot.
     """
-    is_group = (chat_id < 0) # always negative for groups
-    splitted = text.split()[:2]
-    command = splitted[0].strip().lower()
+    is_group = (chat_id < 0)  # always negative for groups
+    split_cmd = text.split()[:2]
+    command = split_cmd[0].strip().lower()
 
     # make sure command is known
     if command not in ('/activate', '/deactivate', '/help'):
@@ -208,9 +232,42 @@ def filter_commands(text, chat_id, correct_ident):
     if not is_group:
         return command
     # check bot_ident
-    if len(splitted)<2:
+    if len(split_cmd) < 2:
         return 'no_ident'
-    if splitted[1].strip() != correct_ident:
+    if split_cmd[1].strip() != correct_ident:
         return 'wrong_ident'
-    
+
     return command
+
+
+class CustomClient(object):
+    """Handles all http requests using telegram api methods"""
+
+    def __init__(self, tg_bot_token):
+        self.token = tg_bot_token
+        self.client = httpclient.AsyncHTTPClient()
+        self.get_updates = self.fetchmaker('getUpdates')
+        self.send_message = self.fetchmaker('sendMessage')
+
+    def url(self, tg_api_method):
+        """construct url from base url, bot token and api method"""
+        base_url = 'https://api.telegram.org/bot%s/%s'
+        return base_url % (self.token, tg_api_method)
+
+    def fetchmaker(self, telegram_api_method):
+        """Receives api method as string and returns
+        wrapper around AsyncHTTPClient's fetch method
+        """
+
+        fetch = self.client.fetch
+        request = self.url(telegram_api_method)
+
+        def _fetcher(body, method='POST', headers=None):
+            """Uses fetch method of tornado http client."""
+            body = json.dumps(body)
+            if not headers:
+                headers = {}
+            headers.update({'Content-Type': 'application/json'})
+            return fetch(
+                request=request, body=body, method=method, headers=headers)
+        return _fetcher

--- a/graphite_beacon/handlers/telegram.py
+++ b/graphite_beacon/handlers/telegram.py
@@ -4,6 +4,12 @@ from tornado import gen, httpclient
 from graphite_beacon.handlers import AbstractHandler, LOGGER
 from graphite_beacon.template import TEMPLATES
 
+NO_CHATFILE = (
+    'chatfile not found in configs. If you want telegram handler to '
+    'persist chats and groups in which you activate bot after '
+    'graphite-beacon is restarted, create blank text file and write '
+    'it`s path to chatfile field in your config file.')
+
 class TelegramHandler(AbstractHandler):
 
     name = 'telegram'
@@ -11,7 +17,8 @@ class TelegramHandler(AbstractHandler):
     # Default options
     defaults = {
         'token': None,
-        'bot_ident': None
+        'bot_ident': None,
+        'chatfile': None
     }
 
     def init_handler(self):
@@ -22,11 +29,142 @@ class TelegramHandler(AbstractHandler):
         self.bot_ident = self.options.get('bot_ident')
         assert self.bot_ident, 'Telegram bot ident token is not defined.'
 
+        self.chatfile = self.options.get('chatfile')
+        if not self.chatfile: LOGGER.warning(NO_CHATFILE)
+
         self.client = httpclient.AsyncHTTPClient()
         self.url = 'https://api.telegram.org/bot%s/' % (self.token)
 
-        self._chats = []
+        self._chats = self._get_chatlist()
         self._listen_commands()
+
+    @gen.coroutine
+    def _listen_commands(self):
+
+        self._last_update = None
+
+        update_body = {"timeout": 2}
+
+        while True:
+
+            if self._last_update:
+                update_body.update({"offset": self._last_update + 1})
+
+            req = self._prepare_request('getUpdates', update_body)
+            update_resp = self.client.fetch(**req)
+
+            update_resp.add_done_callback(self._respond_commands)
+            yield gen.sleep(5)
+
+    @gen.coroutine
+    def _respond_commands(self, update_response):
+        chatfile = self.chatfile
+
+        if update_response.exception():
+            LOGGER.error(str(update_response.exception()))
+
+        upd = update_response.result().body
+        if not upd:
+            return
+
+        update_content = json.loads(upd.decode())
+        for update in update_content['result']:
+
+            update_id = update.get('update_id')
+            if not update_id: continue
+
+            message = update.get('message')  # fix key error here
+            if not message: continue
+
+            text = message.get('text')
+            if not text: continue
+
+            message_id = message.get('message_id')
+            if not message_id: continue
+
+            chat_id = message.get('chat', {}).get('id')
+            if not chat_id: continue
+
+            if not self._correct_activation(text, chat_id):
+                continue
+
+            self._last_update = update_id
+
+            if chat_id not in self._chats:
+                reply_text = 'Activated!'
+
+                LOGGER.debug('Adding chat [%s] to notify list'
+                                % (chat_id))
+                self._chats.append(int(chat_id))
+
+                if chatfile:
+                    LOGGER.debug('Writing chat [%s] to file %s'
+                                    % (chat_id, chatfile))
+                    self._save_to_file(chat_id, chatfile)
+
+            else:
+                reply_text = 'This chat is already activated'
+
+            response_body = {
+                "chat_id": chat_id,
+                "reply_to_message_id": message_id,
+                "text": reply_text}
+
+            bot_response = self._prepare_request('sendMessage', response_body)
+            yield self.client.fetch(**bot_response)
+
+    @gen.coroutine
+    def notify(self, level, *args, **kwargs):
+        request_url = self.url + 'sendMessage'
+
+        LOGGER.debug('Handler (%s) %s', self.name, level)
+
+        notify_text = self.get_message(level, *args, **kwargs)
+        for chat in self._chats:
+
+            body = {"chat_id": chat, "text": notify_text}
+            notification = self._prepare_request('sendMessage', body)
+
+            yield self.client.fetch(**notification)
+
+    def _get_chatlist(self):
+        try:
+            with open(self.chatfile) as fh:
+                return [int(chat) for chat in fh]
+        except Exception as e:
+            LOGGER.debug('could not load saved chats:\n%s' % (e))
+            return []
+
+    def _prepare_request(self, target, body, method='POST',
+                            headers={"Content-Type": "application/json"}):
+
+        return dict(request=self.url + target, body=json.dumps(body),
+                    method=method, headers=headers,)
+
+    def _correct_activation(self, text, chat_id):
+        """Helper method, called from _respond_commands
+        when bot gets message from user.
+        If chat_id is positive, we don't call bot from group
+        or channel so there is no need to check bot_ident.
+        """
+        splitted = text.split()
+        init = splitted[0].strip().lower()
+        init_iscorrect = init.startswith(r'/activate')
+
+        if int(chat_id) > 0:
+            return init_iscorrect
+
+        elif len(splitted) >= 2:
+            bot_id = splitted[1].strip()
+            bot_id_iscorrect = bot_id.startswith(self.bot_ident)
+            return (init_iscorrect and bot_id_iscorrect)
+
+        else:
+            return False
+
+    def _save_to_file(self, chat_id, chatfile):
+        with open(chatfile, 'a') as fh:
+            fh.write('%s\n' % (chat_id))
 
     def get_message(self, level, alert, value,
                     target=None, ntype=None, rule=None):
@@ -35,85 +173,5 @@ class TelegramHandler(AbstractHandler):
         tmpl = TEMPLATES[ntype][msg_type]
         generated = tmpl.generate(
             level=level, reactor=self.reactor, alert=alert,
-            value=value, target=target)
+            value=value, target=target,)
         return generated.decode().strip()
-
-    @gen.coroutine
-    def _listen_commands(self):
-
-        self._last_update = None
-
-        update_body = {'timeout': 2}
-
-        update_headers = {'Content-Type': 'application/json'}
-
-        while True:
-            if self._last_update:
-                update_body.update({'offset': self._last_update + 1})
-            update_resp = self.client.fetch(
-                self.url + 'getUpdates', headers=update_headers,
-                body=json.dumps(update_body), method='POST')
-            update_resp.add_done_callback(self._respond_commands)
-            yield gen.sleep(5)
-
-    @gen.coroutine
-    def _respond_commands(self, update_response):
-
-        if update_response.exception():
-            LOGGER.error(str(update_response.exception()))
-
-        update_content = update_response.result().body
-        if not update_content:
-            return
-        else:
-            update_content = json.loads(update_content.decode())
-
-        for update in update_content['result']:
-
-            msg = update.get('message')
-            if not msg:
-                continue
-
-            text = msg.get('text')
-            if not text:
-                continue
-
-            msp = text.split()
-            self._last_update = update['update_id']
-            if len(msp) > 1 and msp[0].startswith('/activate'):
-                try:
-                    chat_id = msg['chat']['id']
-                    if msp[1] == self.bot_ident and chat_id not in self._chats:
-                        LOGGER.debug(
-                            'Adding chat [%s] to notify list.', chat_id)
-                        self._chats.append(chat_id)
-                        yield self.client.fetch(
-                            self.url + 'sendMessage', body=json.dumps({
-                                'chat_id': chat_id,
-                                'reply_to_message_id': msg['message_id'],
-                                'text': 'Activated!'}),
-                            method='POST',
-                            headers={'Content-Type': 'application/json'})
-                    elif msp[1] == self.bot_ident and chat_id in self._chats:
-                        yield self.client.fetch(
-                            self.url + 'sendMessage', body=json.dumps({
-                                'chat_id': chat_id,
-                                'reply_to_message_id': msg['message_id'],
-                                'text': 'This chat is already activated.'}),
-                            method='POST',
-                            headers={'Content-Type': 'application/json'})
-                except:
-                    continue
-            else:
-                continue
-
-    @gen.coroutine
-    def notify(self, level, *args, **kwargs):
-
-        LOGGER.debug('Handler (%s) %s', self.name, level)
-
-        message = self.get_message(level, *args, **kwargs)
-        for chat in self._chats:
-            yield self.client.fetch(
-                self.url + 'sendMessage', body=json.dumps({'chat_id': chat, 'text': message}),
-                method='POST', headers={'Content-Type': 'application/json'})

--- a/graphite_beacon/handlers/telegram.py
+++ b/graphite_beacon/handlers/telegram.py
@@ -97,8 +97,8 @@ class TelegramHandler(AbstractHandler):
                     elif msp[1] == self.bot_ident and chat_id in self._chats:
                         yield self.client.fetch(
                             self.url + 'sendMessage', body=json.dumps({
-                                'chat_id': update['message']['chat']['id'],
-                                'reply_to_message_id': update['message']['message_id'],
+                                'chat_id': chat_id,
+                                'reply_to_message_id': msg['message_id'],
                                 'text': 'This chat is already activated.'}),
                             method='POST',
                             headers={'Content-Type': 'application/json'})

--- a/graphite_beacon/handlers/untitled.py
+++ b/graphite_beacon/handlers/untitled.py
@@ -1,1 +1,0 @@
-make file saving static method

--- a/graphite_beacon/handlers/untitled.py
+++ b/graphite_beacon/handlers/untitled.py
@@ -1,0 +1,1 @@
+make file saving static method


### PR DESCRIPTION
Implements #130 
Fixes #127 
Fixes #129 
Some methods return bytes on python3 which was reason of TypeError during json serialization.
Simply using bytes.decode() was enough.
Also removed str.encode() method, which returns bytes on python3 and fixed key error (sometimes handler receives update without 'text' field).
