### PR TITLE
PagerDuty incident resolution support

### DIFF
--- a/graphite_beacon/handlers/pagerduty.py
+++ b/graphite_beacon/handlers/pagerduty.py
@@ -32,17 +32,17 @@ class PagerdutyHandler(AbstractHandler):
         message = self.get_short(level, alert, value, target=target, ntype=ntype, rule=rule)
         LOGGER.debug('message1:%s', message)
 
-	# Extract unique alert identifiers
+        # Extract unique alert identifiers
         alert_name = message[message.find("<")+1:message.find(">")]
         alert_metric = message[message.find("(")+1:message.find(")")]
-	
+
         # Generate hash 
-	h = hashlib.md5()
-	h.update(alert_name)
-	h.update(alert_metric)
+        h = hashlib.md5()
+        h.update(alert_name)
+        h.update(alert_metric)
 
         # Use hash as incident key to support resolution
-	incident_key = h.hexdigest()
+        incident_key = h.hexdigest()
 
         if level == 'critical':
             event_type = "trigger"
@@ -73,5 +73,5 @@ class PagerdutyHandler(AbstractHandler):
             body=json.dumps(data),
             headers=headers,
             method='POST'
-	)
+        )
 


### PR DESCRIPTION
PagerDuty incidents are generated with messages like:

    [BEACON] CRITICAL <Test Wildcard Alert> (stats.gauges.server2.data) failed. Current value: 1.0

"Back to normal" messages look like:

    [BEACON] NORMAL <Test Wildcard Alert> (stats.gauges.server1.data) is back to normal.

From those, I figured that incident-unique information is the combination of alert name (`<Test Wildcard Alert>`) and metrics name (`(stats.gauges.server1.data)`). To avoid storing data on the file system, I decided to generate a hash out of those two. Using this hash value incidents can be triggered and resolved in a stateless way. 

Following tests were performed:
* Tested alerts with exact metric match (`"query": "stats.gauges.test"`)
* Tested wildcard metrics alerts (`"query": "stats.gauges.*.data"`)