### PR TITLE
Increase http clients' max_clients to 100

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -25,6 +25,7 @@ LEVELS = {
     'normal': 20,
 }
 
+hc.AsyncHTTPClient.configure(None, max_clients=100)
 
 class sliceable_deque(deque):
 


### PR DESCRIPTION
When some HTTP requests take too long, the queue of requests gets filled up and other requests, that shouldn't fail, fail too with timeouts / too long to process errors.

Logs showed errors like this: `[simple_httpclient:137:fetch_impl] max_clients limit reached`

So it seems I fell into this case: http://stackoverflow.com/questions/33411493/max-clients-limit-reached-request-queued-tornado

This is a simple (naive?) attempt to fix those errors (based on the stackoverflow answer). Increasing the max number of concurrent requests being processed by tornado seems to fix my problems, on my setup.