### PR TITLE
Add default backward-compatible /config.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,8 @@ ADD docker/supervisor.conf /etc/supervisor/conf.d/deliverous.conf
 ADD docker/update-exim4.conf.conf /etc/exim4/update-exim4.conf.conf
 ADD docker/exim4 /etc/default/exim4
 
+# Add a default /config.json for backward compatibility
+RUN echo '{ "include":["/srv/alerting/etc/config.json"] }' > /config.json
+
 CMD ["/usr/bin/supervisord"]
 


### PR DESCRIPTION
The development version now tries to load config.json from / (instead of
/srv/alerting/etc as before). Just not to break anyone's existing
deployment, this fix adds a default config.json that does nothing but
include /srv/alerting/etc/config.json.

This way, mounting either `/config.json` (new behaviour) or
`/srv/.../config.json` (old behaviour) works.