### PR TITLE
Consider suffix with ".yaml" as yaml config file

### DIFF
--- a/graphite_beacon/core.py
+++ b/graphite_beacon/core.py
@@ -95,7 +95,12 @@ class Reactor(object):
     def include_config(self, config):
         LOGGER.info('Load configuration: %s' % config)
         if config:
-            loader = yaml.load if yaml and config.endswith('.yml') else json.loads
+            if yaml and (config.endswith('.yml') or config.endswith('.yaml')):
+                LOGGER.debug('Using YAML parser')
+                loader = yaml.load
+            else:
+                LOGGER.debug('Using JSON parser')
+                loader = json.loads
             try:
                 with open(config) as fconfig:
                     source = COMMENT_RE.sub("", fconfig.read())

--- a/graphite_beacon/handlers/smtp.py
+++ b/graphite_beacon/handlers/smtp.py
@@ -48,8 +48,8 @@ class SMTPHandler(AbstractHandler):
             yield smtp_starttls(smtp)  # pylint: disable=no-value-for-parameter
 
         if self.options['username'] and self.options['password']:
-            yield smtp_login(smtp, self.options['username'],
-                             self.options['password'])  # pylint: disable=no-value-for-parameter
+            yield smtp_login(smtp, self.options['username'],   # pylint: disable=no-value-for-parameter
+                             self.options['password'])
 
         try:
             LOGGER.debug("Send message to: %s", ", ".join(self.options['to']))

--- a/graphite_beacon/handlers/telegram.py
+++ b/graphite_beacon/handlers/telegram.py
@@ -29,7 +29,7 @@ class TelegramHandler(AbstractHandler):
         self._chats = []
         self._listen_commands()
 
-    def get_message(self, level, alert, value, target=None, ntype=None, rule=None):
+    def get_message(self, level, alert, value, target=None, ntype=None, _=None):
 
         msg_type = 'telegram' if ntype == 'graphite' else 'short'
         tmpl = TEMPLATES[ntype][msg_type]
@@ -39,7 +39,7 @@ class TelegramHandler(AbstractHandler):
     @gen.coroutine
     def _listen_commands(self):
 
-        self._last_update = None
+        self._last_update = None  # pylint: disable=attribute-defined-outside-init
 
         update_body = {"timeout": 2}
 
@@ -71,7 +71,7 @@ class TelegramHandler(AbstractHandler):
                 continue
             message = update["message"]["text"].encode("utf-8")
             msp = message.split()
-            self._last_update = update["update_id"]
+            self._last_update = update["update_id"]  # pylint: disable=attribute-defined-outside-init
             if len(msp) > 1 and msp[0].startswith("/activate"):
                 try:
                     chat_id = update["message"]["chat"]["id"]
@@ -94,7 +94,7 @@ class TelegramHandler(AbstractHandler):
                                 "text": "This chat is already activated."}),
                             method="POST",
                             headers={"Content-Type": "application/json"})
-                except:
+                except Exception:
                     continue
             else:
                 continue


### PR DESCRIPTION
The example config file at: `examples/example-config.yaml` was suffix with ".yaml", but beacon looks it as a json. This patch fix it.