### PR TITLE
Add Content-Type header to slack request for mattermost compatibility

### DIFF
--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -53,4 +53,9 @@ class SlackHandler(AbstractHandler):
             data['channel'] = self.channel
 
         body = json.dumps(data)
-        yield self.client.fetch(self.webhook, method='POST', headers={'Content-Type': 'application/json'}, body=body)
+        yield self.client.fetch(
+            self.webhook,
+            method='POST',
+            headers={'Content-Type': 'application/json'},
+            body=body
+        )

--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -53,4 +53,4 @@ class SlackHandler(AbstractHandler):
             data['channel'] = self.channel
 
         body = json.dumps(data)
-        yield self.client.fetch(self.webhook, method='POST', body=body)
+        yield self.client.fetch(self.webhook, method='POST', headers={'Content-Type': 'application/json'}, body=body)


### PR DESCRIPTION
Mattermost tries to be API-compatible with Slack, but does not (currently) support incoming webhooks in JSON format without the 'Content-Type': 'application/json' header.  Given that the [Slack API documentation](https://api.slack.com/incoming-webhooks) (not to mention [RFC 7231](https://tools.ietf.org/html/rfc7231#section-3.1.1.5)) also specifies a preference for content type to be made explicit, adding the header here seems like reasonable way to make the webhooks handler work for Mattermost while continuing to work for Slack.