### PR TITLE
Allows overriding notification settings per alert

### DIFF
--- a/graphite_beacon/alerts.py
+++ b/graphite_beacon/alerts.py
@@ -91,7 +91,7 @@ class BaseAlert(_.with_metaclass(AlertFabric)):
         """String representation."""
         return "%s (%s)" % (self.name, self.interval)
 
-    def configure(self, name=None, rules=None, query=None, **options):
+    def configure(self, name=None, rules=None, query=None, override=None, **options):
         """Configure the alert."""
         self.name = name
         if not name:
@@ -104,6 +104,8 @@ class BaseAlert(_.with_metaclass(AlertFabric)):
 
         assert query, "%s: Alert's query is invalid" % self.name
         self.query = query
+
+        self.override = override
 
         interval_raw = options.get('interval', self.reactor.options['interval'])
         self.interval = TimeUnit.from_interval(interval_raw)

--- a/graphite_beacon/handlers/cli.py
+++ b/graphite_beacon/handlers/cli.py
@@ -18,7 +18,7 @@ class CliHandler(AbstractHandler):
         self.whitelist = self.options.get('alerts_whitelist')
         assert self.command_template, 'Command line command is not defined.'
 
-    def notify(self, level, *args, **kwargs):
+    def notify(self, level, alert, *args, **kwargs):
         LOGGER.debug("Handler (%s) %s", self.name, level)
 
         def get_alert_name(*args):
@@ -26,9 +26,14 @@ class CliHandler(AbstractHandler):
             # remove time characteristics e.g. (1minute)
             return name.rsplit(' ', 1)[0].strip()
 
+        command_template = self.command_template
+        if alert.override and self.name in alert.override:
+            override = alert.override[self.name]
+            command_template = override.get('command', command_template)
+
         # Run only for whitelisted names if specified
         if not self.whitelist or get_alert_name(*args) in self.whitelist:
-            command = substitute_variables(self.command_template, level, *args, **kwargs)
+            command = substitute_variables(command_template, level, alert, *args, **kwargs)
             subprocess.Popen(
                 command,
                 shell=True,

--- a/graphite_beacon/handlers/http.py
+++ b/graphite_beacon/handlers/http.py
@@ -27,6 +27,15 @@ class HttpHandler(AbstractHandler):
     def notify(self, level, alert, value, target=None, ntype=None, rule=None):
         LOGGER.debug("Handler (%s) %s", self.name, level)
 
+        url = self.url
+        params = self.params
+        method = self.method
+        if alert.override and self.name in alert.override:
+            override = alert.override[self.name]
+            url = override.get('url', url)
+            params = override.get('params', params)
+            method = override.get('method', method)
+
         message = self.get_short(level, alert, value, target=target, ntype=ntype, rule=rule)
         data = {'alert': alert.name, 'desc': message, 'level': level}
         if target:
@@ -38,6 +47,7 @@ class HttpHandler(AbstractHandler):
             data['graph_url'] = alert.get_graph_url(target)
             data['value'] = value
 
-        data.update(self.params)
+        data.update(params)
         body = urllib.urlencode(data)
-        yield self.client.fetch(self.url, method=self.method, body=body)
+        yield self.client.fetch(url, method=method, body=body)
+

--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -24,13 +24,17 @@ class SlackHandler(AbstractHandler):
         'normal': ':white_check_mark:',
     }
 
+    @staticmethod
+    def _make_channel_name(channel):
+        if channel and not channel.startswith(('#', '@')):
+            channel = '#' + channel
+        return channel
+
     def init_handler(self):
         self.webhook = self.options.get('webhook')
         assert self.webhook, 'Slack webhook is not defined.'
 
-        self.channel = self.options.get('channel')
-        if self.channel and not self.channel.startswith(('#', '@')):
-            self.channel = '#' + self.channel
+        self.channel = self._make_channel_name(self.options.get('channel'))
         self.username = self.options.get('username')
         self.client = hc.AsyncHTTPClient()
 
@@ -41,16 +45,23 @@ class SlackHandler(AbstractHandler):
             level=level, reactor=self.reactor, alert=alert, value=value, target=target).strip()
 
     @gen.coroutine
-    def notify(self, level, *args, **kwargs):
+    def notify(self, level, alert, *args, **kwargs):
         LOGGER.debug("Handler (%s) %s", self.name, level)
 
-        message = self.get_message(level, *args, **kwargs)
+        channel = self.channel
+        username = self.username
+        if alert.override and self.name in alert.override:
+            override = alert.override[self.name]
+            channel = self._make_channel_name(override.get('channel', channel))
+            username = override.get('username', username)
+
+        message = self.get_message(level, alert, *args, **kwargs)
         data = dict()
-        data['username'] = self.username
+        data['username'] = username
         data['text'] = message
         data['icon_emoji'] = self.emoji.get(level, ':warning:')
-        if self.channel:
-            data['channel'] = self.channel
+        if channel:
+            data['channel'] = channel
 
         body = json.dumps(data)
         yield self.client.fetch(


### PR DESCRIPTION
This fixes issue https://github.com/klen/graphite-beacon/issues/76, allowing individual alerts to override some notification details (e.g. email recipient, Slack channel).

Example:
```json
      {
        "name": "site-404s",
        "time_window": "10minute",
        "method": "maximum",
        "query": "...",
        "rules": ["warning: > 10"],
        "override": {
          "slack": {
            "channel": "#site-dev"
          },
          "smtp": {
            "to": "dev-site@example.org"
          }
        }
      }
```

Not all fields can be overridden, nor can all alert methods. Overrides usually don't let you change which server you're talking to, or what API key you're using. Available overrides:

<dl>
  <dt>cli</dt>
  <dd><code>command</code></dd>
  <dt>hipchat</dt>
  <dd><code>room</code></dd>
  <dt>http</dt>
  <dd><code>url</code>, <code>params</code>, <code>method</code></dd>
  <dt>slack</dt>
  <dd><code>channel</code>, <code>username</code></dd>
  <dt>smtp</dt>
  <dd><code>sender</code>, <code>to</code></dd>
  <dt>victorops</dt>
  <dd><code>url</code>, <code>routing_key</code></dd>
</dl>