### PR TITLE
Adding graphs for Slack alerts as an 'attachment' so they appear inline.

### DIFF
--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -43,8 +43,7 @@ class SlackHandler(AbstractHandler):
     def get_graph_url(self, level, alert, value, target=None, ntype=None, rule=None):  # pylint: disable=unused-argument
         if target is not None:
             return alert.get_graph_url(target)
-        else:
-            return None
+        return None
 
     @gen.coroutine
     def notify(self, level, *args, **kwargs):

--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -60,7 +60,7 @@ class SlackHandler(AbstractHandler):
         graph_url = self.get_graph_url
         if graph_url is not None:
             data['attachments'] = {
-                'fallback':  'Graph',
+                'fallback': 'Graph',
                 'title': 'Graph',
                 'title_link': graph_url,
                 'image_url': graph_url,

--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -40,6 +40,12 @@ class SlackHandler(AbstractHandler):
         return tmpl.generate(
             level=level, reactor=self.reactor, alert=alert, value=value, target=target).strip()
 
+    def get_graph_url(self, level, alert, value, target=None, ntype=None, rule=None):  # pylint: disable=unused-argument
+        if target is not None:
+            return alert.get_graph_url(target)
+        else:
+            return None
+
     @gen.coroutine
     def notify(self, level, *args, **kwargs):
         LOGGER.debug("Handler (%s) %s", self.name, level)
@@ -51,6 +57,15 @@ class SlackHandler(AbstractHandler):
         data['icon_emoji'] = self.emoji.get(level, ':warning:')
         if self.channel:
             data['channel'] = self.channel
+
+        graph_url = get_graph_url
+        if graph_url is not None:
+            data['attachments'] = {
+                'fallback':  'Graph',
+                'title': 'Graph',
+                'title_link': graph_url,
+                'image_url': graph_url,
+            }
 
         body = json.dumps(data)
         yield self.client.fetch(

--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -58,7 +58,7 @@ class SlackHandler(AbstractHandler):
         if self.channel:
             data['channel'] = self.channel
 
-        graph_url = get_graph_url
+        graph_url = self.get_graph_url
         if graph_url is not None:
             data['attachments'] = {
                 'fallback':  'Graph',

--- a/graphite_beacon/handlers/slack.py
+++ b/graphite_beacon/handlers/slack.py
@@ -40,7 +40,9 @@ class SlackHandler(AbstractHandler):
         return tmpl.generate(
             level=level, reactor=self.reactor, alert=alert, value=value, target=target).strip()
 
-    def get_graph_url(self, level, alert, value, target=None, ntype=None, rule=None):  # pylint: disable=unused-argument
+    # pylint: disable=no-self-use
+    # pylint: disable=unused-argument
+    def get_graph_url(self, level, alert, value, target=None, ntype=None, rule=None):
         if target is not None:
             return alert.get_graph_url(target)
         return None

--- a/graphite_beacon/templates/graphite/slack.txt
+++ b/graphite_beacon/templates/graphite/slack.txt
@@ -2,5 +2,4 @@
 {{ reactor.options.get('prefix') }} {{level.upper() }} <{{ alert.name }}>{% if target %} `{{target}}`{% end %} is back to normal.
 {% else %}
 {{ reactor.options.get('prefix') }} {{ level.upper() }} <{{ alert.name }}>{% if target %} `{{target}}`{% end %} failed. Current value: {{ alert.convert(value) }}
-{% if target %}<{{ alert.get_graph_url(target) }}|View Graph>{% end %}
 {% end %}


### PR DESCRIPTION
Hi there,

I wanted to make a small change the Slack integration so that when a graph is available, it is sent to Slack as an attachment so it appears inline, rather than as a hyperlink in the message.

The tests pass, so I don't think I broke anything, but please note that I haven't actually tested the Slack functionality directly, so let me know if you have any questions/doubts :)

Thanks!