### PR TITLE
Pagerduty, fix incident key: use md5 hash from name and unique url

### DIFF
--- a/graphite_beacon/handlers/pagerduty.py
+++ b/graphite_beacon/handlers/pagerduty.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 
 from tornado import httpclient as hc
 from tornado import gen
@@ -43,9 +44,10 @@ class PagerdutyHandler(AbstractHandler):
         client_url = None
         if target:
             client_url = alert.get_graph_url(target)
-        incident_key = 'graphite connect error'
-        if rule:
-            incident_key = "alert={},rule={}".format(alert.name, rule['raw'])
+        m = hashlib.md5()
+        incident_key_str = "alert={},client_url={}".format(alert.name, client_url)
+        m.update(incident_key_str)
+        incident_key = m.hexdigest()
 
         data = {
             "service_key": self.service_key,


### PR DESCRIPTION
There are several cases old incident_key was not working well:
- warning and critical rules for same alert (non-resolved incident)
- NoData with nodata: critical

alert name + client_url looks unique enough
also we need hash because of length limit ("The maximum permitted length of this property is 255 characters" [ref](https://v2.developer.pagerduty.com/docs/trigger-events))